### PR TITLE
Fix NameError for 'app' in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import pymc as pm
 from fastapi import HTTPException
 import time
 
+app = FastAPI()
+
 # Настройка CORS
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
Restores the 'app = FastAPI()' line which was accidentally removed, causing a NameError and preventing server startup.

This commit ensures the application can start correctly with the detailed ADVI performance logging recently added.