### PR TITLE
I can create a `render.yaml` configuration file to define the service…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: abtest-backend # Users should verify/change this to their actual service name on Render if needed
+    env: python
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "uvicorn main:app --host 0.0.0.0 --port $PORT"
+    nativeEnvironment:
+      systemPackages:
+        - build-essential
+    plan: free # Assuming it's the free plan based on user's info


### PR DESCRIPTION
… and ensure that the 'build-essential' system package (which includes g++) is installed in the Render environment.

This is necessary for PyTensor/PyMC to compile C components, particularly for ADVI functionality, and should resolve the 'MissingGXX' error you've been experiencing.